### PR TITLE
Refactor to use shared tools

### DIFF
--- a/DayTrader_XGBoost.py
+++ b/DayTrader_XGBoost.py
@@ -8,6 +8,7 @@ import talib  # For technical indicators
 from functools import reduce
 import optuna  # For Bayesian optimization
 import matplotlib.pyplot as plt
+from DayTrader_tools import load_and_rename_data, create_lagged_features, add_technical_indicators
 
 # Define file paths and tickers
 file_paths = {
@@ -16,25 +17,6 @@ file_paths = {
 }
 
 # Load and rename data
-def load_and_rename_data(file_path, ticker):
-    try:
-        df = pd.read_csv(file_path, parse_dates=['datetime'])
-        column_mapping = {
-            'v': f'volume_{ticker}',
-            'vw': f'vw_{ticker}',
-            'o': f'open_{ticker}',
-            'c': f'close_{ticker}',
-            'h': f'high_{ticker}',
-            'l': f'low_{ticker}',
-            'n': f'trades_{ticker}'
-        }
-        df.rename(columns=column_mapping, inplace=True)
-        selected_columns = ['datetime'] + list(column_mapping.values())
-        df = df[selected_columns]
-        return df
-    except Exception as e:
-        print(f"Error processing {ticker}: {e}")
-        return None
 
 # Load data for all tickers
 price_data_list = [load_and_rename_data(file_paths[ticker], ticker) for ticker in file_paths]
@@ -46,54 +28,20 @@ price_data.fillna(method='ffill', inplace=True)
 
 '''
 # Create lagged features legacy
-def create_lagged_features(data, ticker, lag_periods):
-    for lag in lag_periods:
-        data[f'{ticker}_lag{lag}'] = data[f'close_{ticker}'].shift(lag)
-    return data
+# def create_lagged_features(data, ticker, lag_periods):
+#     for lag in lag_periods:
+#         data[f'{ticker}_lag{lag}'] = data[f'close_{ticker}'].shift(lag)
+#     return data
 '''
-    
-# Function to create lagged features
-def create_lagged_features(data, ticker, lag_periods):
-    for lag in lag_periods:
-        lag_col = f'close_{ticker}_lag{lag}'
-        data[lag_col] = data[f'close_{ticker}'].shift(lag)
-    return data
+
+# Function to create lagged features provided by DayTrader_tools
 
 lag_periods = [1, 2, 3, 4, 5]
 for ticker in file_paths:
     price_data = create_lagged_features(price_data, ticker, lag_periods)
 
-# Add all technical indicators
-def add_technical_indicators(data, ticker):
-    close_col = f'close_{ticker}'
-    high_col = f'high_{ticker}'
-    low_col = f'low_{ticker}'
 
-    data[f'MA50_{ticker}'] = data[close_col].rolling(window=50).mean()
-    data[f'EMA20_{ticker}'] = data[close_col].ewm(span=20, adjust=False).mean()
-    data[f'RSI_{ticker}'] = talib.RSI(data[close_col], timeperiod=14)
-
-    upper_band, middle_band, lower_band = talib.BBANDS(data[close_col], timeperiod=20)
-    data[f'upper_bb_{ticker}'] = upper_band
-    data[f'middle_bb_{ticker}'] = middle_band
-    data[f'lower_bb_{ticker}'] = lower_band
-
-    data[f'ATR_{ticker}'] = talib.ATR(data[high_col], data[low_col], data[close_col], timeperiod=14)
-
-    macd, macd_signal, _ = talib.MACD(data[close_col], fastperiod=12, slowperiod=26, signalperiod=9)
-    data[f'MACD_{ticker}'] = macd
-    data[f'MACD_signal_{ticker}'] = macd_signal
-
-    data[f'ADX_{ticker}'] = talib.ADX(data[high_col], data[low_col], data[close_col], timeperiod=14)
-
-    slowk, slowd = talib.STOCH(data[high_col], data[low_col], data[close_col], fastk_period=14, slowk_period=3, slowd_period=3)
-    data[f'StochK_{ticker}'] = slowk
-    data[f'StochD_{ticker}'] = slowd
-
-    data[f'CCI_{ticker}'] = talib.CCI(data[high_col], data[low_col], data[close_col], timeperiod=20)
-    data[f'WilliamsR_{ticker}'] = talib.WILLR(data[high_col], data[low_col], data[close_col], timeperiod=14)
-
-    return data
+# Add all technical indicators provided by DayTrader_tools
 
 for ticker in file_paths:
     price_data = add_technical_indicators(price_data, ticker)

--- a/DayTrader_XGBoost_module.py
+++ b/DayTrader_XGBoost_module.py
@@ -10,6 +10,7 @@ import optuna  # For Bayesian optimization
 import matplotlib.pyplot as plt
 import os
 import shutil
+from DayTrader_tools import load_and_rename_data, create_lagged_features, add_technical_indicators
 
 def run_analysis(folder,csv_file_path):
     # Extract stock symbol from CSV filename (e.g., "XOM.csv" -> "XOM")
@@ -20,26 +21,7 @@ def run_analysis(folder,csv_file_path):
         'XOM': csv_file_path,  # Replace with your actual file paths
     }
 
-    # Load and rename data
-    def load_and_rename_data(file_path, ticker):
-        try:
-            df = pd.read_csv(file_path, parse_dates=['datetime'])
-            column_mapping = {
-                'v': f'volume_{ticker}',
-                'vw': f'vw_{ticker}',
-                'o': f'open_{ticker}',
-                'c': f'close_{ticker}',
-                'h': f'high_{ticker}',
-                'l': f'low_{ticker}',
-                'n': f'trades_{ticker}'
-            }
-            df.rename(columns=column_mapping, inplace=True)
-            selected_columns = ['datetime'] + list(column_mapping.values())
-            df = df[selected_columns]
-            return df
-        except Exception as e:
-            print(f"Error processing {ticker}: {e}")
-            return None
+    # Load and rename data using utility function
 
     # Load data for all tickers
     price_data_list = [load_and_rename_data(file_paths[ticker], ticker) for ticker in file_paths]
@@ -51,54 +33,19 @@ def run_analysis(folder,csv_file_path):
 
     '''
     # Create lagged features legacy
-    def create_lagged_features(data, ticker, lag_periods):
-        for lag in lag_periods:
-            data[f'{ticker}_lag{lag}'] = data[f'close_{ticker}'].shift(lag)
-        return data
+    # def create_lagged_features(data, ticker, lag_periods):
+    #     for lag in lag_periods:
+    #         data[f'{ticker}_lag{lag}'] = data[f'close_{ticker}'].shift(lag)
+    #     return data
     '''
-        
-    # Function to create lagged features
-    def create_lagged_features(data, ticker, lag_periods):
-        for lag in lag_periods:
-            lag_col = f'close_{ticker}_lag{lag}'
-            data[lag_col] = data[f'close_{ticker}'].shift(lag)
-        return data
+
+    # Function to create lagged features provided by DayTrader_tools
 
     lag_periods = [1, 2, 3, 4, 5]
     for ticker in file_paths:
         price_data = create_lagged_features(price_data, ticker, lag_periods)
 
-    # Add all technical indicators
-    def add_technical_indicators(data, ticker):
-        close_col = f'close_{ticker}'
-        high_col = f'high_{ticker}'
-        low_col = f'low_{ticker}'
-
-        data[f'MA50_{ticker}'] = data[close_col].rolling(window=50).mean()
-        data[f'EMA20_{ticker}'] = data[close_col].ewm(span=20, adjust=False).mean()
-        data[f'RSI_{ticker}'] = talib.RSI(data[close_col], timeperiod=14)
-
-        upper_band, middle_band, lower_band = talib.BBANDS(data[close_col], timeperiod=20)
-        data[f'upper_bb_{ticker}'] = upper_band
-        data[f'middle_bb_{ticker}'] = middle_band
-        data[f'lower_bb_{ticker}'] = lower_band
-
-        data[f'ATR_{ticker}'] = talib.ATR(data[high_col], data[low_col], data[close_col], timeperiod=14)
-
-        macd, macd_signal, _ = talib.MACD(data[close_col], fastperiod=12, slowperiod=26, signalperiod=9)
-        data[f'MACD_{ticker}'] = macd
-        data[f'MACD_signal_{ticker}'] = macd_signal
-
-        data[f'ADX_{ticker}'] = talib.ADX(data[high_col], data[low_col], data[close_col], timeperiod=14)
-
-        slowk, slowd = talib.STOCH(data[high_col], data[low_col], data[close_col], fastk_period=14, slowk_period=3, slowd_period=3)
-        data[f'StochK_{ticker}'] = slowk
-        data[f'StochD_{ticker}'] = slowd
-
-        data[f'CCI_{ticker}'] = talib.CCI(data[high_col], data[low_col], data[close_col], timeperiod=20)
-        data[f'WilliamsR_{ticker}'] = talib.WILLR(data[high_col], data[low_col], data[close_col], timeperiod=14)
-
-        return data
+    # Add all technical indicators provided by DayTrader_tools
 
     for ticker in file_paths:
         price_data = add_technical_indicators(price_data, ticker)

--- a/DayTrader_XGBoost_no_plot.py
+++ b/DayTrader_XGBoost_no_plot.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 import os
 import shutil
 from tqdm import tqdm
+from DayTrader_tools import load_and_rename_data, create_lagged_features, add_technical_indicators
 
 # Define file paths and tickers
 file_paths = {
@@ -19,25 +20,6 @@ file_paths = {
 }
 
 # Load and rename data
-def load_and_rename_data(file_path, ticker):
-    try:
-        df = pd.read_csv(file_path, parse_dates=['datetime'])
-        column_mapping = {
-            'v': f'volume_{ticker}',
-            'vw': f'vw_{ticker}',
-            'o': f'open_{ticker}',
-            'c': f'close_{ticker}',
-            'h': f'high_{ticker}',
-            'l': f'low_{ticker}',
-            'n': f'trades_{ticker}'
-        }
-        df.rename(columns=column_mapping, inplace=True)
-        selected_columns = ['datetime'] + list(column_mapping.values())
-        df = df[selected_columns]
-        return df
-    except Exception as e:
-        print(f"Error processing {ticker}: {e}")
-        return None
 
 # Load data for all tickers
 price_data_list = [load_and_rename_data(file_paths[ticker], ticker) for ticker in file_paths]
@@ -49,54 +31,20 @@ price_data.fillna(method='ffill', inplace=True)
 
 '''
 # Create lagged features legacy
-def create_lagged_features(data, ticker, lag_periods):
-    for lag in lag_periods:
-        data[f'{ticker}_lag{lag}'] = data[f'close_{ticker}'].shift(lag)
-    return data
+# def create_lagged_features(data, ticker, lag_periods):
+#     for lag in lag_periods:
+#         data[f'{ticker}_lag{lag}'] = data[f'close_{ticker}'].shift(lag)
+#     return data
 '''
-    
-# Function to create lagged features
-def create_lagged_features(data, ticker, lag_periods):
-    for lag in lag_periods:
-        lag_col = f'close_{ticker}_lag{lag}'
-        data[lag_col] = data[f'close_{ticker}'].shift(lag)
-    return data
+
+# Function to create lagged features provided by DayTrader_tools
 
 lag_periods = [1, 2, 3, 4, 5]
 for ticker in file_paths:
     price_data = create_lagged_features(price_data, ticker, lag_periods)
 
-# Add all technical indicators
-def add_technical_indicators(data, ticker):
-    close_col = f'close_{ticker}'
-    high_col = f'high_{ticker}'
-    low_col = f'low_{ticker}'
 
-    data[f'MA50_{ticker}'] = data[close_col].rolling(window=50).mean()
-    data[f'EMA20_{ticker}'] = data[close_col].ewm(span=20, adjust=False).mean()
-    data[f'RSI_{ticker}'] = talib.RSI(data[close_col], timeperiod=14)
-
-    upper_band, middle_band, lower_band = talib.BBANDS(data[close_col], timeperiod=20)
-    data[f'upper_bb_{ticker}'] = upper_band
-    data[f'middle_bb_{ticker}'] = middle_band
-    data[f'lower_bb_{ticker}'] = lower_band
-
-    data[f'ATR_{ticker}'] = talib.ATR(data[high_col], data[low_col], data[close_col], timeperiod=14)
-
-    macd, macd_signal, _ = talib.MACD(data[close_col], fastperiod=12, slowperiod=26, signalperiod=9)
-    data[f'MACD_{ticker}'] = macd
-    data[f'MACD_signal_{ticker}'] = macd_signal
-
-    data[f'ADX_{ticker}'] = talib.ADX(data[high_col], data[low_col], data[close_col], timeperiod=14)
-
-    slowk, slowd = talib.STOCH(data[high_col], data[low_col], data[close_col], fastk_period=14, slowk_period=3, slowd_period=3)
-    data[f'StochK_{ticker}'] = slowk
-    data[f'StochD_{ticker}'] = slowd
-
-    data[f'CCI_{ticker}'] = talib.CCI(data[high_col], data[low_col], data[close_col], timeperiod=20)
-    data[f'WilliamsR_{ticker}'] = talib.WILLR(data[high_col], data[low_col], data[close_col], timeperiod=14)
-
-    return data
+# Add all technical indicators provided by DayTrader_tools
 
 for ticker in file_paths:
     price_data = add_technical_indicators(price_data, ticker)

--- a/DayTrader_tools.py
+++ b/DayTrader_tools.py
@@ -1,3 +1,6 @@
+import pandas as pd
+import talib
+
 # Function to create lagged features
 def create_lagged_features(data, ticker, lag_periods):
     for lag in lag_periods:


### PR DESCRIPTION
## Summary
- centralize utility functions for loading data, building lags and technical indicators in `DayTrader_tools.py`
- use these helpers in all XGBoost scripts rather than redefining them

## Testing
- `python3 -m py_compile DayTrader_tools.py DayTrader_XGBoost.py DayTrader_XGBoost_no_plot.py DayTrader_XGBoost_module.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1b776d1883308e9bb2b8e5e98e13